### PR TITLE
Add automated stale PR cleanup workflow

### DIFF
--- a/.github/workflows/stale-pr-cleanup.yml
+++ b/.github/workflows/stale-pr-cleanup.yml
@@ -1,0 +1,23 @@
+name: Close stale PRs
+on:
+  schedule:
+    - cron: "30 1 * * *"  # Runs at 1:30 AM UTC daily
+
+jobs:
+  stale:
+    runs-on: preprod-xs-runner
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # PR settings
+          stale-pr-message: "This PR is stale because it has been open 2 days with no activity. It will be closed in 4 days if no further activity occurs."
+          close-pr-message: "This PR was closed because it has been inactive for 4 days since being marked as stale."
+          days-before-pr-stale: 2
+          days-before-pr-close: 4
+
+          # Optional: Customize labels
+          stale-pr-label: "stale"
+
+          # Only focus on PRs, disable for issues
+          days-before-issue-stale: -1
+          days-before-issue-close: -1


### PR DESCRIPTION
# Adding Stale PR Cleanup Workflow

This PR introduces an automated workflow to manage stale pull requests using GitHub Actions.

## What's included
- Automated stale PR detection and cleanup
- Configurable timing rules (2 days to mark stale, 4 days to close)
- Daily scheduled execution at 1:30 AM UTC
- Clear messaging to contributors about PR lifecycle

## How it works
- PRs become stale after 2 days of inactivity
- Stale PRs are automatically closed after 4 additional days
- Contributors receive clear notifications before closure
- Focuses only on PRs (issues are excluded)

This helps maintain a clean repository by automatically managing inactive pull requests.
